### PR TITLE
Fix map not shown bug

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,14 +14,9 @@
         map:cameraTargetLat="54.6872"
         map:cameraTargetLng="25.2797"
         map:cameraZoom="11"
-        map:uiTiltGestures="false"
         map:uiRotateGestures="false"
+        map:uiTiltGestures="false"
         tools:visibility="gone" />
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@drawable/center_gradient" />
 
     <com.bluelinelabs.conductor.ChangeHandlerFrameLayout
         android:id="@+id/controller_container"


### PR DESCRIPTION
It fixes this https://github.com/gyvosistorijos/gyvos-istorijos-android/issues/16
Problem wasn't related to map. It was related to gradient which was painted. It is Android bug https://code.google.com/p/android/issues/detail?id=71065 
Also it crashes on Android 21 https://console.firebase.google.com/project/gyvos-istorijos/monitoring/app/android:lt.gyvosistorijos/cluster/19adb20b?duration=2592000000
It's against google TOS to hide Google maps logo, so disabling it temporary